### PR TITLE
Fix AssertExpression definition

### DIFF
--- a/docs/modules/types.html
+++ b/docs/modules/types.html
@@ -110,7 +110,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-module">
 					<a name="assertexpression" class="tsd-anchor"></a>
 					<h3>Assert<wbr>Expression</h3>
-					<div class="tsd-signature tsd-kind-icon">Assert<wbr>Expression<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
+					<div class="tsd-signature tsd-kind-icon">Assert<wbr>Expression<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/product-os/jellyfish-assert/blob/master/lib/types.ts#L15">types.ts:15</a></li>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,7 +12,7 @@ export type AssertContext = object | null;
 /**
  * Expression to assert.
  */
-export type AssertExpression = true | false | null | undefined;
+export type AssertExpression = string | number | boolean | null | undefined;
 
 /**
  * A function that returns a string.


### PR DESCRIPTION
AssertExpression should also accept a string or number value.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***